### PR TITLE
Code typo in discriminator sample

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1073,7 +1073,7 @@ The following sample illustrates this usage.
           type: string
         address:
           type: string
-          format: ipv6
+          format: ipv4
         ...
 
     Ipv6Addr: <-- object involved in oneOf MUST include the objectype property
@@ -1086,7 +1086,7 @@ The following sample illustrates this usage.
           type: string
         address:
           type: string
-          format: ipv4
+          format: ipv6
         ...
 
 ```


### PR DESCRIPTION
The format values ipv6 and ipv4 were switched around

#### What type of PR is this?

Add one of the following kinds:
* documentation



#### What this PR does / why we need it:
Fixes code typo in 11.5.1 samples: the format values for ipv4 and ipv6 were switched around



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #47 

#### Special notes for reviewers:



#### Changelog input

```
Fixed code typo in 11.5.1

```

#### Additional documentation 

This section can be blank.



```
docs

```
